### PR TITLE
Add a default user object so we don't crash when we get a null user.

### DIFF
--- a/client/utils/RenderToRoot.js
+++ b/client/utils/RenderToRoot.js
@@ -32,7 +32,7 @@ const RenderToRoot = (Element) => {
     return (
       <ErrorBoundary className="mt-3">
         <SiteCustomizationContext.Provider value={reactProps?.siteCustomizations ?? DEFAULT_SITE_CUSTOMIZATIONS}>
-          <UserContext.Provider value={reactProps?.user}>
+          <UserContext.Provider value={reactProps?.user ?? { _id: null, username: 'Anonymous User' }}>
             <Element {...reactProps} />
           </UserContext.Provider>
         </SiteCustomizationContext.Provider>


### PR DESCRIPTION
This caused occasional errors when a user wasn't logged in.