### PR TITLE
Correctly escape some card link urls.

### DIFF
--- a/client/components/CubeSearchNavBar.js
+++ b/client/components/CubeSearchNavBar.js
@@ -122,7 +122,7 @@ const AdvancedSearchModal = ({ isOpen, toggle }) => {
     }
 
     if (queryText.length > 0) {
-      window.location.href = `/cubes/search/${queryText.trim()}/0`;
+      window.location.href = `/cubes/search/${encodeURIComponent(queryText.trim())}/0`;
     } else {
       window.location.href = '/cubes/search';
     }

--- a/client/pages/CardPage.js
+++ b/client/pages/CardPage.js
@@ -75,6 +75,7 @@ import {
   getCardMarketLink,
   getCardHoarderLink,
   getCardKingdomLink,
+  nameToDashedUrlComponent,
 } from '@cubeartisan/client/utils/Affiliate.js';
 import { ArrowSwitchIcon, CheckIcon, ClippyIcon } from '@primer/octicons-react';
 import styled from '@cubeartisan/client/utils/styledHelper.js';
@@ -565,7 +566,7 @@ export const CardPage = ({ card, data, versions, related, loginCallback }) => {
                         outline
                         color="success"
                         block
-                        href={`https://edhrec.com/cards/${card.name}`}
+                        href={`https://edhrec.com/cards/${nameToDashedUrlComponent(card.name)}`}
                         target="_blank"
                       >
                         View on EDHRec

--- a/client/utils/Affiliate.js
+++ b/client/utils/Affiliate.js
@@ -44,6 +44,8 @@ const ck = (str) =>
     .replace(/[:,."']/g, '')
     .toLowerCase();
 
+export const nameToDashedUrlComponent = ck;
+
 export const getCardKingdomLink = (card) =>
   `https://www.cardkingdom.com/mtg/${ck(card.details.set_name)}/${ck(card.details.name)}`;
 


### PR DESCRIPTION
Ported over from dekkerglen/CubeCobra#2160.